### PR TITLE
feat: improve nav menu toggle styling

### DIFF
--- a/src/layouts/default.astro
+++ b/src/layouts/default.astro
@@ -184,7 +184,20 @@ const { title = 'LWJ Productions' } = Astro.props;
 			}
 
 			.nav-toggle {
+				align-self: center;
+				background: color-mix(in oklch, var(--gray-400) 60%, transparent);
+				border: 1px solid color-mix(in oklch, var(--white) 15%, transparent);
+				border-radius: 1.5rem;
+				box-shadow: 0 1px 2px color-mix(in oklch, var(--gray-500) 80%, transparent);
+				color: var(--white);
+				font-family: jwf-medium;
+				font-size: 0.875rem;
+				justify-self: center;
+				letter-spacing: 0.1em;
+				line-height: 1.75;
+				padding: 0.5rem 1.625rem;
 				pointer-events: all;
+				text-transform: uppercase;
 
 				@media (min-width: 1080px) {
 					display: none;


### PR DESCRIPTION
Closes #3 

This adds some style improvements to the nav menu toggle. See video:

https://github.com/user-attachments/assets/efe7a52f-837e-4bae-b277-8ab8305465c7

Basically, I just applied similar styling to the full nav menu, adjusting some of the values for the toggle styles to get the font size and heights to match up.