### PR TITLE
fix: nav popover scroll issue

### DIFF
--- a/src/layouts/default.astro
+++ b/src/layouts/default.astro
@@ -116,6 +116,23 @@ const { title = 'LWJ Productions' } = Astro.props;
 </script>
 
 <style>
+	/* This prevents background scrolling when the nav menu popover is visible. */
+	html:has(#menu:popover-open) {
+		overflow:hidden;
+	}
+
+	/* This allows the header and nav menu popover to be full screen height when the popover is visible. */
+	header:has(#menu:popover-open) {
+		position: fixed;
+		min-height: 100%;
+		top: 0;
+		& .nav-group {
+			position: fixed;
+			min-height: 100%;
+			top: 0;
+		}
+	}
+
 	header {
 		inline-size: 100dvi;
 		inset-block-start: 0;


### PR DESCRIPTION
Closes #4 

Here's how I solved this, but let me know if you'd prefer an alternative solution. I applied the following styles:

- This prevents background scrolling when the nav menu popover is visible:
    ```css
	html:has(#menu:popover-open) {
    	overflow:hidden;
	}
    ```
- This was a bit tricky, because the `.nav-group` div is a child of the `header` element and so cannot escape the bounds of the `header`. I had to adjust the both the `header` and the `.nav-group`'s position and height when the popover is open so that they could take up the full screen: 
    ```css
	header:has(#menu:popover-open) {
		position: fixed;
		min-height: 100%;
		top: 0;
		& .nav-group {
			position: fixed;
			min-height: 100%;
			top: 0;
		}
	}
    ```

Here is how it looks:

https://github.com/user-attachments/assets/76c2ad1e-612c-4e50-a991-8ec2d2368ad4

