### PR TITLE
fix: links hidden by nav popover are clickable

### DIFF
--- a/src/layouts/default.astro
+++ b/src/layouts/default.astro
@@ -116,6 +116,16 @@ const { title = 'LWJ Productions' } = Astro.props;
 </script>
 
 <style>
+	/* When the nav popover is visible:
+	   1. Disable anchor tags from being targets of pointer events to prevent clicking links under the popover
+	   2. Ensure that the anchor tags in the nav popover menu still are clickable
+	*/
+	html:has(#menu:popover-open) {
+		a:not(#menu a) {
+			pointer-events: none;
+		}
+	}
+
 	header {
 		inline-size: 100dvi;
 		inset-block-start: 0;


### PR DESCRIPTION
Closes #6 

Note: This commit and the one in #4 touch the same area of the same file and will likely cause a merge conflict. If both of these are accepted, then I'll do a rebase to fix the conflict after the first of the two is accepted/merged.

Turned out to be an easy CSS fix for this once figured out. It essentially disables pointer events on all anchor tags except the ones in the popover nav menu when the popover is open. Notice in the video that the pointer no longer changes to a pointer when hovering over anchor elements under the popover like it did in the video included in the Issue ticket and if those areas are clicked it now only dismisses the popover and does not navigate away from the page.

https://github.com/user-attachments/assets/d10d8995-c910-4900-ac12-1efd76348391

