### PR TITLE
fix: nav popover hides search panel

### DIFF
--- a/src/layouts/default.astro
+++ b/src/layouts/default.astro
@@ -111,6 +111,7 @@ const { title = 'LWJ Productions' } = Astro.props;
 			'[data-name="main-search"]',
 		) as HTMLButtonElement;
 
+		(document.querySelector("#menu:popover-open") as HTMLElement)?.hidePopover();
 		search.click();
 	});
 </script>


### PR DESCRIPTION
Closes #7 

This updates the nav search button's click handler to include a call to close the nav popover.

https://github.com/user-attachments/assets/2abd9f8b-48a4-4fcb-92c1-fddb0a175794

